### PR TITLE
feat: add chromatic aberration final effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# my-nft-gen
+, # my-nft-gen
 
 🎞️ Searching for the perfect loop?
 
@@ -35,7 +35,7 @@ Explore the code and examples to learn more.
 
 Effects are too numerous to fit comfortably here. See the companion repository [nft-scratch](https://github.com/john-paul-ruf/nft-scratch) for examples of usage.
 
-* **Final Effects**: e.g. `BlurEffect`, `GlitchDrumrollHorizontalWave`, `PixelateEffect`
+* **Final Effects**: e.g. `BlurEffect`, `GlitchDrumrollHorizontalWave`, `PixelateEffect`, `ChromaticAberrationEffect`
 * **Primary Effects**: e.g. `AmpEffect`, `BlinkOnEffect`, `EncircledSpiral`, `FuzzFlareEffect`, `FuzzyBandEffect`, `GatesEffect`
 * Most effects support animated transitions, color pickers, ranges, feathering, glitching, and compositing
 

--- a/src/core/layer/LayerEffectFromJSON.js
+++ b/src/core/layer/LayerEffectFromJSON.js
@@ -3,6 +3,7 @@ import { SingleLayerGlitchDrumrollHorizontalWaveEffect } from '../../effects/sec
 import { GlitchFractalEffect } from '../../effects/finalImageEffects/glitchFractal/GlitchFractalEffect.js';
 import { GlitchInverseEffect } from '../../effects/finalImageEffects/glitchInverse/GlitchInverseEffect.js';
 import { PixelateEffect } from '../../effects/finalImageEffects/pixelate/PixelateEffect.js';
+import { ChromaticAberrationEffect } from '../../effects/finalImageEffects/chromaticAberration/ChromaticAberrationEffect.js';
 import { AmpEffect } from '../../effects/primaryEffects/amp/AmpEffect.js';
 import { BlinkOnEffect } from '../../effects/primaryEffects/blink-on-blink-on-blink-redux/BlinkOnEffect.js';
 import { EncircledSpiralEffect } from '../../effects/primaryEffects/encircledSpiral/EncircledSpiralEffect.js';
@@ -73,6 +74,9 @@ export class LayerEffectFromJSON {
                 break;
             case PixelateEffect._name_:
                 layer = Object.assign(new PixelateEffect({}), json);
+                break;
+            case ChromaticAberrationEffect._name_:
+                layer = Object.assign(new ChromaticAberrationEffect({}), json);
                 break;
             case ModulateEffect._name_:
                 layer = Object.assign(new ModulateEffect({}), json);

--- a/src/effects/finalImageEffects/chromaticAberration/ChromaticAberrationConfig.js
+++ b/src/effects/finalImageEffects/chromaticAberration/ChromaticAberrationConfig.js
@@ -1,0 +1,20 @@
+import { EffectConfig } from '../../../core/layer/EffectConfig.js';
+
+/**
+ * Config for Chromatic Aberration Effect
+ * Shifts color channels to create an RGB split/glitch effect.
+ * Can be glitched to appear on a percentage of frames generated.
+ *
+ * @offsetRange - lower and upper bound for pixel offset applied to channels
+ * @glitchChance - percent chance this effect applies to a given frame
+ */
+export class ChromaticAberrationConfig extends EffectConfig {
+    constructor({
+        offsetRange = { lower: 1, upper: 5 },
+        glitchChance = 50,
+    }) {
+        super();
+        this.offsetRange = offsetRange;
+        this.glitchChance = glitchChance;
+    }
+}

--- a/src/effects/finalImageEffects/chromaticAberration/ChromaticAberrationEffect.js
+++ b/src/effects/finalImageEffects/chromaticAberration/ChromaticAberrationEffect.js
@@ -1,0 +1,100 @@
+import { promises as fs } from 'fs';
+import Jimp from 'jimp';
+import { LayerEffect } from '../../../core/layer/LayerEffect.js';
+import { getRandomIntInclusive, randomId } from '../../../core/math/random.js';
+import { findValue } from '../../../core/math/findValue.js';
+import { Settings } from '../../../core/Settings.js';
+import { ChromaticAberrationConfig } from './ChromaticAberrationConfig.js';
+
+/**
+ * Chromatic Aberration Effect
+ * Renders red, green and blue channel copies offset from each other.
+ * Can be glitched to appear on a percentage of the frames generated.
+ * Instantiated through the project via the LayerConfig.
+ */
+export class ChromaticAberrationEffect extends LayerEffect {
+    static _name_ = 'chromatic-aberration';
+
+    constructor({
+        name = ChromaticAberrationEffect._name_,
+        requiresLayer = true,
+        config = new ChromaticAberrationConfig({}),
+        additionalEffects = [],
+        ignoreAdditionalEffects = false,
+        settings = new Settings({}),
+    }) {
+        super({
+            name,
+            requiresLayer,
+            config,
+            additionalEffects,
+            ignoreAdditionalEffects,
+            settings,
+        });
+        this.#generate(settings);
+    }
+
+    async #chromaticAberration(layer, currentFrame, totalFrames) {
+        const theGlitch = getRandomIntInclusive(0, 100);
+        if (theGlitch > this.data.glitchChance) {
+            return;
+        }
+
+        const filename = `${this.workingDirectory}chromatic-aberration${randomId()}.png`;
+
+        await layer.toFile(filename);
+
+        const base = await Jimp.read(filename);
+        const width = base.bitmap.width;
+        const height = base.bitmap.height;
+
+        const offset = Math.floor(findValue(0, this.data.offset, 1, totalFrames, currentFrame));
+
+        const red = base.clone();
+        red.scan(0, 0, width, height, function (x, y, idx) {
+            this.bitmap.data[idx + 1] = 0;
+            this.bitmap.data[idx + 2] = 0;
+        });
+
+        const green = base.clone();
+        green.scan(0, 0, width, height, function (x, y, idx) {
+            this.bitmap.data[idx + 0] = 0;
+            this.bitmap.data[idx + 2] = 0;
+        });
+
+        const blue = base.clone();
+        blue.scan(0, 0, width, height, function (x, y, idx) {
+            this.bitmap.data[idx + 0] = 0;
+            this.bitmap.data[idx + 1] = 0;
+        });
+
+        const output = new Jimp(width, height, 0x00000000);
+        output.composite(red, offset, 0);
+        output.composite(green, -offset, 0);
+        output.composite(blue, 0, 0);
+
+        await output.writeAsync(filename);
+        await layer.fromFile(filename);
+        await fs.unlink(filename);
+    }
+
+    #generate(settings) {
+        this.data = {
+            glitchChance: this.config.glitchChance,
+            offset: getRandomIntInclusive(
+                this.config.offsetRange.lower,
+                this.config.offsetRange.upper,
+            ),
+            getInfo: () => {},
+        };
+    }
+
+    async invoke(layer, currentFrame, numberOfFrames) {
+        await this.#chromaticAberration(layer, currentFrame, numberOfFrames);
+        await super.invoke(layer, currentFrame, numberOfFrames);
+    }
+
+    getInfo() {
+        return `${this.name}: ${this.data.glitchChance} chance, offset up to ${this.data.offset}`;
+    }
+}


### PR DESCRIPTION
## Summary
- add ChromaticAberrationEffect to split and offset RGB channels
- expose configurable channel offset and glitch chance
- document chromatic aberration final effect

## Testing
- `npm test` *(fails: findValue tests and MultiStepDefinition getRandomFindValueAlgorithm undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68b8919605c0832690e411cc677f9c58