### PR TITLE
feat: add perlin noise primary effect

### DIFF
--- a/src/core/layer/LayerEffectFromJSON.js
+++ b/src/core/layer/LayerEffectFromJSON.js
@@ -49,6 +49,7 @@ import {
     StaticImageKeyFrameEffect
 } from "../../effects/keyFrameEffects/staticImageKeyFrame/StaticImageKeyFrameEffect.js";
 import { RollingGradientEffect } from "../../effects/primaryEffects/rollingGradient/RollingGradientEffect.js";
+import { PerlinNoiseEffect } from "../../effects/primaryEffects/perlinNoise/PerlinNoiseEffect.js";
 import {SetOpacityKeyFrameEffect} from "../../effects/keyFrameEffects/setOpacity/SetOpacityKeyFrameEffect.js";
 import {BloomFilmGrainEffect} from "../../effects/finalImageEffects/bloomFilmGrain/BloomFilmGrainEffect.js";
 import {EdgeGlowEffect} from "../../effects/secondaryEffects/edgeGlow/EdgeGlowEffect.js";
@@ -169,6 +170,9 @@ export class LayerEffectFromJSON {
                 break;
             case RollingGradientEffect._name_:
                 layer = Object.assign(new RollingGradientEffect({}), json);
+                break;
+            case PerlinNoiseEffect._name_:
+                layer = Object.assign(new PerlinNoiseEffect({}), json);
                 break;
             case ClaudeCRTBarrelRollEffect._name_:
                 layer = Object.assign(new ClaudeCRTBarrelRollEffect({}), json);

--- a/src/effects/primaryEffects/perlinNoise/PerlinNoiseConfig.js
+++ b/src/effects/primaryEffects/perlinNoise/PerlinNoiseConfig.js
@@ -1,0 +1,20 @@
+import {EffectConfig} from '../../../core/layer/EffectConfig.js';
+
+/**
+ * Configuration for PerlinNoiseEffect
+ * @param scale - base frequency of the noise (0-1)
+ * @param speed - amount to change noise seed per frame
+ * @param colorScheme - [lowColor, highColor] hex color array
+ */
+export class PerlinNoiseConfig extends EffectConfig {
+    constructor({
+                    scale = 0.02,
+                    speed = 1,
+                    colorScheme = ['#000000', '#ffffff'],
+                } = {}) {
+        super();
+        this.scale = scale;
+        this.speed = speed;
+        this.colorScheme = colorScheme;
+    }
+}

--- a/src/effects/primaryEffects/perlinNoise/PerlinNoiseEffect.js
+++ b/src/effects/primaryEffects/perlinNoise/PerlinNoiseEffect.js
@@ -1,0 +1,86 @@
+import {LayerEffect} from '../../../core/layer/LayerEffect.js';
+import {Canvas2dFactory} from '../../../core/factory/canvas/Canvas2dFactory.js';
+import {Settings} from '../../../core/Settings.js';
+import {PerlinNoiseConfig} from './PerlinNoiseConfig.js';
+
+/**
+ * PerlinNoiseEffect
+ * Renders animated Perlin noise using SVG turbulence filtered and tinted by a color scheme.
+ */
+export class PerlinNoiseEffect extends LayerEffect {
+    static _name_ = 'perlin-noise';
+
+    constructor({
+                    name = PerlinNoiseEffect._name_,
+                    requiresLayer = true,
+                    config = new PerlinNoiseConfig({}),
+                    additionalEffects = [],
+                    ignoreAdditionalEffects = false,
+                    settings = new Settings({}),
+                } = {}) {
+        super({
+            name,
+            requiresLayer,
+            config,
+            additionalEffects,
+            ignoreAdditionalEffects,
+            settings,
+        });
+        this.#generate(settings);
+    }
+
+    #generate(settings) {
+        this.data = {
+            width: this.finalSize.width,
+            height: this.finalSize.height,
+            scale: this.config.scale,
+            speed: this.config.speed,
+            colorScheme: this.config.colorScheme,
+            seed: Math.floor(Math.random() * 10000),
+        };
+    }
+
+    async #drawNoise(context) {
+        const { width, height, scale, colorScheme, seed, speed } = context.data;
+        const canvas = await Canvas2dFactory.getNewCanvas(width, height);
+
+        const baseFrequency = scale;
+        const frameSeed = seed + context.currentFrame * speed;
+        const [lowColor, highColor] = colorScheme;
+
+        const parseColor = (hex) => ({
+            r: parseInt(hex.slice(1,3),16) / 255,
+            g: parseInt(hex.slice(3,5),16) / 255,
+            b: parseInt(hex.slice(5,7),16) / 255,
+        });
+
+        const low = parseColor(lowColor);
+        const high = parseColor(highColor);
+        const filterId = `perlin_${Math.random().toString(36).substr(2,9)}`;
+
+        canvas.strategy.elements.push(`<defs>
+  <filter id="${filterId}">
+    <feTurbulence type="fractalNoise" baseFrequency="${baseFrequency}" numOctaves="1" seed="${frameSeed}" result="noise" />
+    <feComponentTransfer in="noise" result="colorNoise">
+      <feFuncR type="table" tableValues="${low.r} ${high.r}" />
+      <feFuncG type="table" tableValues="${low.g} ${high.g}" />
+      <feFuncB type="table" tableValues="${low.b} ${high.b}" />
+    </feComponentTransfer>
+  </filter>
+</defs>`);
+        canvas.strategy.elements.push(`<rect x="0" y="0" width="${width}" height="${height}" filter="url(#${filterId})" />`);
+
+        const layer = await canvas.convertToLayer();
+        await context.layer.compositeLayerOver(layer);
+    }
+
+    async invoke(layer, currentFrame, numberOfFrames) {
+        const context = { currentFrame, numberOfFrames, data: this.data, layer };
+        await this.#drawNoise(context);
+        await super.invoke(layer, currentFrame, numberOfFrames);
+    }
+
+    getInfo() {
+        return `${this.name}: scale ${this.data.scale}, speed ${this.data.speed}`;
+    }
+}

--- a/src/effects/primaryEffects/perlinNoise/README.md
+++ b/src/effects/primaryEffects/perlinNoise/README.md
@@ -1,0 +1,11 @@
+# PerlinNoiseEffect
+
+Generates an animated Perlin noise texture and tints it with a color gradient.
+
+## Parameters
+- `scale`: Base frequency for the noise, smaller values yield larger patterns.
+- `speed`: Amount the noise seed changes each frame to animate the texture.
+- `colorScheme`: Array `[lowColor, highColor]` mapping noise values to colors.
+
+## Usage
+See `src/perlin-noise-test.js` for an example project using this effect.

--- a/src/perlin-noise-test.js
+++ b/src/perlin-noise-test.js
@@ -1,0 +1,37 @@
+import {Project} from './app/Project.js';
+import {LayerConfig} from './core/layer/LayerConfig.js';
+import {PerlinNoiseEffect} from './effects/primaryEffects/perlinNoise/PerlinNoiseEffect.js';
+import {PerlinNoiseConfig} from './effects/primaryEffects/perlinNoise/PerlinNoiseConfig.js';
+import {ColorScheme} from './core/color/ColorScheme.js';
+
+const createPerlinNoiseTest = async () => {
+    const myTestProject = new Project({
+        artist: 'John Ruf',
+        projectName: 'perlin-noise-test',
+        projectDirectory: 'output/perlin-noise-test',
+        neutrals: ['#FFFFFF'],
+        backgrounds: ['#000000'],
+        numberOfFrame: 60,
+        colorScheme: new ColorScheme({
+            colorBucket: ['#ff0000', '#00ff00', '#0000ff']
+        }),
+        longestSideInPixels: 640,
+        shortestSideInPixels: 640
+    });
+
+    await myTestProject.addPrimaryEffect({
+        layerConfig: new LayerConfig({
+            effect: PerlinNoiseEffect,
+            percentChance: 100,
+            currentEffectConfig: new PerlinNoiseConfig({
+                scale: 0.02,
+                speed: 1,
+                colorScheme: ['#000000', '#ff00ff']
+            }),
+        }),
+    });
+
+    await myTestProject.generateRandomLoop();
+};
+
+await createPerlinNoiseTest();


### PR DESCRIPTION
## Summary
- add PerlinNoiseConfig and PerlinNoiseEffect for animated noise textures
- register perlin-noise in LayerEffectFromJSON and document usage
- include example script showcasing the new effect

## Testing
- `npm test` *(fails: findValue.test.js and findMultiStepValue.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b891b42608832689113989716448cd