### PR TITLE
feat: add color pulse final image effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Explore the code and examples to learn more.
 
 Effects are too numerous to fit comfortably here. See the companion repository [nft-scratch](https://github.com/john-paul-ruf/nft-scratch) for examples of usage.
 
-* **Final Effects**: e.g. `BlurEffect`, `GlitchDrumrollHorizontalWave`, `PixelateEffect`
+* **Final Effects**: e.g. `BlurEffect`, `ColorPulseEffect`, `GlitchDrumrollHorizontalWave`, `PixelateEffect`
 * **Primary Effects**: e.g. `AmpEffect`, `BlinkOnEffect`, `EncircledSpiral`, `FuzzFlareEffect`, `FuzzyBandEffect`, `GatesEffect`
 * Most effects support animated transitions, color pickers, ranges, feathering, glitching, and compositing
 

--- a/docs/ColorPulseEffect.md
+++ b/docs/ColorPulseEffect.md
@@ -1,0 +1,35 @@
+# ColorPulseEffect
+
+The **ColorPulseEffect** is a final image effect that creates rhythmic changes in saturation and brightness. Values follow a sinusoidal curve, giving the image a breathing, pulsating quality. A glitch system can introduce occasional spikes for extra energy.
+
+## Configuration
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `pulseAmount` | Number | Amplitude of the pulse. `0.1` is subtle, `0.5` is intense. |
+| `pulseSpeed` | Number | Number of full pulses across the animation. `2` means two complete cycles. |
+| `glitchChance` | Number | Percent chance per frame to add a random spike to the intensity. |
+
+## Examples
+
+```js
+// Gentle breathing pulse
+new ColorPulseEffect({
+  config: new ColorPulseConfig({
+    pulseAmount: 0.1,
+    pulseSpeed: 1,
+    glitchChance: 0,
+  })
+});
+
+// Rapid pulse with occasional bursts
+new ColorPulseEffect({
+  config: new ColorPulseConfig({
+    pulseAmount: 0.5,
+    pulseSpeed: 4,
+    glitchChance: 15,
+  })
+});
+```
+
+The first example produces a soft, almost imperceptible modulation, while the second creates a high-intensity strobe-like effect with random surges in saturation and brightness.

--- a/src/core/layer/LayerEffectFromJSON.js
+++ b/src/core/layer/LayerEffectFromJSON.js
@@ -41,6 +41,7 @@ import { BlurKeyFrameEffect } from '../../effects/keyFrameEffects/blur/BlurKeyFr
 import { StaticPathEffect } from '../../effects/primaryEffects/static-path/StaticPathEffect.js';
 import { StaticPathConfig } from '../../effects/primaryEffects/static-path/StaticPathConfig.js';
 import { ModulateEffect } from '../../effects/finalImageEffects/modulate/ModulateEffect.js';
+import { ColorPulseEffect } from '../../effects/finalImageEffects/colorPulse/ColorPulseEffect.js';
 import {ArcPath} from "../position/ArcPath.js";
 import {Position} from "../position/Position.js";
 import {CurvedRedEyeConfig} from "../../effects/primaryEffects/curved-red-eye/CurvedRedEyeConfig.js";
@@ -76,6 +77,9 @@ export class LayerEffectFromJSON {
                 break;
             case ModulateEffect._name_:
                 layer = Object.assign(new ModulateEffect({}), json);
+                break;
+            case ColorPulseEffect._name_:
+                layer = Object.assign(new ColorPulseEffect({}), json);
                 break;
             case AmpEffect._name_:
                 layer = Object.assign(new AmpEffect({}), json);

--- a/src/effects/finalImageEffects/colorPulse/ColorPulseConfig.js
+++ b/src/effects/finalImageEffects/colorPulse/ColorPulseConfig.js
@@ -1,0 +1,22 @@
+import {EffectConfig} from '../../../core/layer/EffectConfig.js';
+
+/**
+ * Configuration for ColorPulseEffect.
+ * Pulses saturation and brightness using a sinusoidal wave.
+ *
+ * @pulseAmount - amplitude of the pulse (0-1 range typical)
+ * @pulseSpeed - number of pulses across the total animation frames
+ * @glitchChance - percent chance per frame to add a random spike
+ */
+export class ColorPulseConfig extends EffectConfig {
+    constructor({
+        pulseAmount = 0.2,
+        pulseSpeed = 2,
+        glitchChance = 5,
+    } = {}) {
+        super();
+        this.pulseAmount = pulseAmount;
+        this.pulseSpeed = pulseSpeed;
+        this.glitchChance = glitchChance;
+    }
+}

--- a/src/effects/finalImageEffects/colorPulse/ColorPulseEffect.js
+++ b/src/effects/finalImageEffects/colorPulse/ColorPulseEffect.js
@@ -1,0 +1,67 @@
+import {LayerEffect} from '../../../core/layer/LayerEffect.js';
+import {Settings} from '../../../core/Settings.js';
+import {ColorPulseConfig} from './ColorPulseConfig.js';
+import {getRandomIntInclusive} from '../../../core/math/random.js';
+
+/**
+ * ColorPulseEffect
+ *
+ * Modulates the final image saturation and brightness using a sinusoidal
+ * waveform. An optional glitch chance introduces irregular spikes in
+ * intensity.
+ */
+export class ColorPulseEffect extends LayerEffect {
+    static _name_ = 'colorPulse';
+
+    constructor({
+        name = ColorPulseEffect._name_,
+        requiresLayer = true,
+        config = new ColorPulseConfig({}),
+        additionalEffects = [],
+        ignoreAdditionalEffects = false,
+        settings = new Settings({}),
+    } = {}) {
+        super({
+            name,
+            requiresLayer,
+            config,
+            additionalEffects,
+            ignoreAdditionalEffects,
+            settings,
+        });
+        this.#generate(settings);
+    }
+
+    async #pulse(layer, currentFrame, totalFrames) {
+        const t = currentFrame / totalFrames;
+        const angle = t * this.data.pulseSpeed * Math.PI * 2;
+        let factor = 1 + this.data.pulseAmount * Math.sin(angle);
+
+        const glitchRoll = getRandomIntInclusive(0, 100);
+        if (glitchRoll <= this.data.glitchChance) {
+            factor += this.data.pulseAmount * Math.random();
+        }
+
+        await layer.modulate({
+            saturation: factor,
+            brightness: factor,
+        });
+    }
+
+    #generate(settings) {
+        this.data = {
+            pulseAmount: this.config.pulseAmount,
+            pulseSpeed: this.config.pulseSpeed,
+            glitchChance: this.config.glitchChance,
+        };
+    }
+
+    async invoke(layer, currentFrame, totalFrames) {
+        await this.#pulse(layer, currentFrame, totalFrames);
+        await super.invoke(layer, currentFrame, totalFrames);
+    }
+
+    getInfo() {
+        return `${this.name}: amount ${this.data.pulseAmount}, speed ${this.data.pulseSpeed}, glitch ${this.data.glitchChance}`;
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable ColorPulse final image effect
- register ColorPulseEffect in LayerEffectFromJSON
- document ColorPulse configuration and usage examples

## Testing
- ❌ `npm test` (fails: findValue tests and undefined getRandomFindValueAlgorithm)
- ⚠️ `npm run quick-test` (produced frame logs but was interrupted due to long runtime)


------
https://chatgpt.com/codex/tasks/task_e_68b8922b5a94832687d9d3cb6aaffa8a