### PR TITLE
Add VintageFade final image effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# my-nft-gen
+, # my-nft-gen
 
 🎞️ Searching for the perfect loop?
 
@@ -35,7 +35,7 @@ Explore the code and examples to learn more.
 
 Effects are too numerous to fit comfortably here. See the companion repository [nft-scratch](https://github.com/john-paul-ruf/nft-scratch) for examples of usage.
 
-* **Final Effects**: e.g. `BlurEffect`, `GlitchDrumrollHorizontalWave`, `PixelateEffect`
+* **Final Effects**: e.g. `BlurEffect`, `GlitchDrumrollHorizontalWave`, `PixelateEffect`, `VintageFadeEffect`
 * **Primary Effects**: e.g. `AmpEffect`, `BlinkOnEffect`, `EncircledSpiral`, `FuzzFlareEffect`, `FuzzyBandEffect`, `GatesEffect`
 * Most effects support animated transitions, color pickers, ranges, feathering, glitching, and compositing
 

--- a/docs/vintage-fade-effect.md
+++ b/docs/vintage-fade-effect.md
@@ -1,0 +1,24 @@
+# VintageFadeEffect
+
+Applies a warm vintage color wash and animated grain.
+
+## Usage
+
+```javascript
+import {VintageFadeEffect} from './src/effects/finalImageEffects/vintageFade/VintageFadeEffect.js';
+import {VintageFadeConfig} from './src/effects/finalImageEffects/vintageFade/VintageFadeConfig.js';
+
+const effect = new VintageFadeEffect({
+  config: new VintageFadeConfig({
+    warmth: {lower: 0.2, upper: 0.4},
+    grainIntensity: {lower: 0.05, upper: 0.15},
+    flickerSpeed: {lower: 2, upper: 6}
+  })
+});
+```
+
+## Configuration
+
+- `warmth`: range controlling the strength of the warm color overlay.
+- `grainIntensity`: range controlling grain noise strength.
+- `flickerSpeed`: range for how many times the grain opacity flickers over the animation.

--- a/src/core/layer/LayerEffectFromJSON.js
+++ b/src/core/layer/LayerEffectFromJSON.js
@@ -52,8 +52,7 @@ import { RollingGradientEffect } from "../../effects/primaryEffects/rollingGradi
 import {SetOpacityKeyFrameEffect} from "../../effects/keyFrameEffects/setOpacity/SetOpacityKeyFrameEffect.js";
 import {BloomFilmGrainEffect} from "../../effects/finalImageEffects/bloomFilmGrain/BloomFilmGrainEffect.js";
 import {EdgeGlowEffect} from "../../effects/secondaryEffects/edgeGlow/EdgeGlowEffect.js";
-import {ClaudeCRTBarrelRollEffect} from "../../effects/finalImageEffects/claudeCRTBarrelRoll/ClaudeCRTBarrelRollEffect.js";
-
+import {VintageFadeEffect} from '../../effects/finalImageEffects/vintageFade/VintageFadeEffect.js';
 export class LayerEffectFromJSON {
     static from(json) {
         let layer = new LayerEffect({});
@@ -166,6 +165,9 @@ export class LayerEffectFromJSON {
                 break;
             case BloomFilmGrainEffect._name_:
                 layer = Object.assign(new BloomFilmGrainEffect({}), json);
+                break;
+            case VintageFadeEffect._name_:
+                layer = Object.assign(new VintageFadeEffect({}), json);
                 break;
             case RollingGradientEffect._name_:
                 layer = Object.assign(new RollingGradientEffect({}), json);

--- a/src/core/layer/LayerEffectFromJSON.js
+++ b/src/core/layer/LayerEffectFromJSON.js
@@ -54,6 +54,9 @@ import {SetOpacityKeyFrameEffect} from "../../effects/keyFrameEffects/setOpacity
 import {BloomFilmGrainEffect} from "../../effects/finalImageEffects/bloomFilmGrain/BloomFilmGrainEffect.js";
 import {EdgeGlowEffect} from "../../effects/secondaryEffects/edgeGlow/EdgeGlowEffect.js";
 import {VintageFadeEffect} from '../../effects/finalImageEffects/vintageFade/VintageFadeEffect.js';
+import {
+    ClaudeCRTBarrelRollEffect
+} from "../../effects/finalImageEffects/claudeCRTBarrelRoll/ClaudeCRTBarrelRollEffect.js";
 export class LayerEffectFromJSON {
     static from(json) {
         let layer = new LayerEffect({});

--- a/src/effects/finalImageEffects/vintageFade/VintageFadeConfig.js
+++ b/src/effects/finalImageEffects/vintageFade/VintageFadeConfig.js
@@ -1,0 +1,21 @@
+import {EffectConfig} from '../../../core/layer/EffectConfig.js';
+import {getAllFindValueAlgorithms} from '../../../core/math/findValue.js';
+
+/**
+ * Config for VintageFadeEffect
+ * Controls warmth, grain intensity and flicker speed
+ */
+export class VintageFadeConfig extends EffectConfig {
+    constructor({
+        warmth = {lower: 0.15, upper: 0.35},
+        grainIntensity = {lower: 0.05, upper: 0.15},
+        flickerSpeed = {lower: 2, upper: 6},
+        flickerFindValueAlgorithm = getAllFindValueAlgorithms(),
+    } = {}) {
+        super();
+        this.warmth = warmth;
+        this.grainIntensity = grainIntensity;
+        this.flickerSpeed = flickerSpeed;
+        this.flickerFindValueAlgorithm = flickerFindValueAlgorithm;
+    }
+}

--- a/src/effects/finalImageEffects/vintageFade/VintageFadeEffect.js
+++ b/src/effects/finalImageEffects/vintageFade/VintageFadeEffect.js
@@ -1,0 +1,95 @@
+import {LayerEffect} from '../../../core/layer/LayerEffect.js';
+import {getRandomFromArray, getRandomIntInclusive, randomId, randomNumber} from '../../../core/math/random.js';
+import {findValue} from '../../../core/math/findValue.js';
+import {Settings} from '../../../core/Settings.js';
+import {VintageFadeConfig} from './VintageFadeConfig.js';
+import sharp from 'sharp';
+import {promises as fs} from 'fs';
+import {globalBufferPool} from '../../../core/pool/BufferPool.js';
+
+export class VintageFadeEffect extends LayerEffect {
+    static _name_ = 'vintage-fade';
+
+    constructor({
+                    name = VintageFadeEffect._name_,
+                    requiresLayer = true,
+                    config = new VintageFadeConfig({}),
+                    additionalEffects = [],
+                    ignoreAdditionalEffects = false,
+                    settings = new Settings({}),
+                } = {}) {
+        super({name, requiresLayer, config, additionalEffects, ignoreAdditionalEffects, settings});
+        this.finalSize = settings.finalSize;
+        this.#generate(settings);
+    }
+
+    #createGrainBuffer(width, height, intensity) {
+        const buf = globalBufferPool.getBuffer(width, height, 4);
+        for (let i = 0; i < buf.length; i += 4) {
+            const noise = (Math.random() - 0.5) * 2; // -1 to 1
+            const value = Math.floor(128 + noise * 127 * intensity);
+            const clamped = Math.max(0, Math.min(255, value));
+            buf[i] = clamped;
+            buf[i + 1] = clamped;
+            buf[i + 2] = clamped;
+            buf[i + 3] = 255;
+        }
+        return buf;
+    }
+
+    async #effect(layer, currentFrame, totalFrames) {
+        const layerOut = `${this.workingDirectory}vintage-fade${randomId()}.png`;
+        const finalOut = `${this.workingDirectory}vintage-fade${randomId()}.png`;
+
+        await layer.toFile(layerOut);
+
+        const warmBuffer = await sharp({
+            create: {
+                width: this.finalSize.width,
+                height: this.finalSize.height,
+                channels: 4,
+                background: { r: 255, g: 200, b: 150, alpha: Math.round(this.data.warmth * 255) }
+            }
+        }).png().toBuffer();
+
+        const grainBuffer = this.#createGrainBuffer(this.finalSize.width, this.finalSize.height, this.data.grainIntensity);
+        const grainOpacity = findValue(0, 1, this.data.flickerSpeed, totalFrames, currentFrame, this.data.flickerFindValueAlgorithm);
+
+        await sharp(layerOut)
+            .composite([
+                { input: warmBuffer, blend: 'overlay' },
+                {
+                    input: grainBuffer,
+                    raw: { width: this.finalSize.width, height: this.finalSize.height, channels: 4 },
+                    blend: 'overlay',
+                    opacity: grainOpacity
+                }
+            ])
+            .toFile(finalOut);
+
+        layer.fromFile(finalOut);
+
+        globalBufferPool.returnBuffer(grainBuffer, this.finalSize.width, this.finalSize.height, 4);
+
+        await fs.unlink(layerOut);
+        await fs.unlink(finalOut);
+    }
+
+    #generate(settings) {
+        this.data = {
+            warmth: randomNumber(this.config.warmth.lower, this.config.warmth.upper),
+            grainIntensity: randomNumber(this.config.grainIntensity.lower, this.config.grainIntensity.upper),
+            flickerSpeed: getRandomIntInclusive(this.config.flickerSpeed.lower, this.config.flickerSpeed.upper),
+            flickerFindValueAlgorithm: getRandomFromArray(this.config.flickerFindValueAlgorithm),
+        };
+    }
+
+    async invoke(layer, currentFrame, numberOfFrames) {
+        await this.#effect(layer, currentFrame, numberOfFrames);
+        await super.invoke(layer, currentFrame, numberOfFrames);
+    }
+
+    getInfo() {
+        return `${this.name}: warmth ${this.data.warmth.toFixed(2)}, grain ${this.data.grainIntensity.toFixed(2)}, flicker ${this.data.flickerSpeed} times`;
+    }
+}


### PR DESCRIPTION
## Summary
- add VintageFade final effect with warmth and flickering grain
- register VintageFade in effect loader
- document VintageFade usage and options

## Testing
- `npm test` *(fails: findValue and findMultiStepValue tests)*
- `npm run quick-test` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68b89220988c8326ab2f183f1283d30b