### PR TITLE
feat: add animated cross-process effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ Explore the code and examples to learn more.
 
 Effects are too numerous to fit comfortably here. See the companion repository [nft-scratch](https://github.com/john-paul-ruf/nft-scratch) for examples of usage.
 
-* **Final Effects**: e.g. `BlurEffect`, `GlitchDrumrollHorizontalWave`, `PixelateEffect`
+* **Final Effects**: e.g. `BlurEffect`, `GlitchDrumrollHorizontalWave`, `PixelateEffect`, `AnimatedCrossProcessEffect`
 * **Primary Effects**: e.g. `AmpEffect`, `BlinkOnEffect`, `EncircledSpiral`, `FuzzFlareEffect`, `FuzzyBandEffect`, `GatesEffect`
 * Most effects support animated transitions, color pickers, ranges, feathering, glitching, and compositing
+
+### AnimatedCrossProcessEffect
+
+Simulates film cross-processing by remapping each color channel with a nonlinear curve. The hue shifts between the values in `hueShiftRange` over time using `cycleSpeed` and the `findValue` helper, while `contrast` adjusts overall intensity.
 
 ---
 

--- a/src/core/layer/LayerEffectFromJSON.js
+++ b/src/core/layer/LayerEffectFromJSON.js
@@ -3,6 +3,7 @@ import { SingleLayerGlitchDrumrollHorizontalWaveEffect } from '../../effects/sec
 import { GlitchFractalEffect } from '../../effects/finalImageEffects/glitchFractal/GlitchFractalEffect.js';
 import { GlitchInverseEffect } from '../../effects/finalImageEffects/glitchInverse/GlitchInverseEffect.js';
 import { PixelateEffect } from '../../effects/finalImageEffects/pixelate/PixelateEffect.js';
+import { AnimatedCrossProcessEffect } from '../../effects/finalImageEffects/animatedCrossProcess/AnimatedCrossProcessEffect.js';
 import { AmpEffect } from '../../effects/primaryEffects/amp/AmpEffect.js';
 import { BlinkOnEffect } from '../../effects/primaryEffects/blink-on-blink-on-blink-redux/BlinkOnEffect.js';
 import { EncircledSpiralEffect } from '../../effects/primaryEffects/encircledSpiral/EncircledSpiralEffect.js';
@@ -73,6 +74,9 @@ export class LayerEffectFromJSON {
                 break;
             case PixelateEffect._name_:
                 layer = Object.assign(new PixelateEffect({}), json);
+                break;
+            case AnimatedCrossProcessEffect._name_:
+                layer = Object.assign(new AnimatedCrossProcessEffect({}), json);
                 break;
             case ModulateEffect._name_:
                 layer = Object.assign(new ModulateEffect({}), json);

--- a/src/effects/finalImageEffects/animatedCrossProcess/AnimatedCrossProcessConfig.js
+++ b/src/effects/finalImageEffects/animatedCrossProcess/AnimatedCrossProcessConfig.js
@@ -1,0 +1,22 @@
+import {EffectConfig} from '../../../core/layer/EffectConfig.js';
+
+/**
+ * Config for AnimatedCrossProcessEffect
+ * Simulates film cross-processing with animated hue shifts.
+ *
+ * @hueShiftRange - minimum and maximum hue shift in degrees
+ * @contrast - range for image contrast adjustment (-1 to 1)
+ * @cycleSpeed - number of hue oscillation cycles over total frames
+ */
+export class AnimatedCrossProcessConfig extends EffectConfig {
+    constructor({
+        hueShiftRange = { lower: -30, upper: 30 },
+        contrast = { lower: 0, upper: 0.4 },
+        cycleSpeed = { lower: 1, upper: 3 },
+    } = {}) {
+        super();
+        this.hueShiftRange = hueShiftRange;
+        this.contrast = contrast;
+        this.cycleSpeed = cycleSpeed;
+    }
+}

--- a/src/effects/finalImageEffects/animatedCrossProcess/AnimatedCrossProcessEffect.js
+++ b/src/effects/finalImageEffects/animatedCrossProcess/AnimatedCrossProcessEffect.js
@@ -1,0 +1,89 @@
+import {promises as fs} from 'fs';
+import Jimp from 'jimp';
+import {LayerEffect} from '../../../core/layer/LayerEffect.js';
+import {findValue} from '../../../core/math/findValue.js';
+import {Settings} from '../../../core/Settings.js';
+import {getRandomIntInclusive, randomNumber, randomId} from '../../../core/math/random.js';
+import {AnimatedCrossProcessConfig} from './AnimatedCrossProcessConfig.js';
+
+export class AnimatedCrossProcessEffect extends LayerEffect {
+    static _name_ = 'animated-cross-process';
+
+    constructor({
+        name = AnimatedCrossProcessEffect._name_,
+        requiresLayer = true,
+        config = new AnimatedCrossProcessConfig({}),
+        additionalEffects = [],
+        ignoreAdditionalEffects = false,
+        settings = new Settings({}),
+    }) {
+        super({
+            name,
+            requiresLayer,
+            config,
+            additionalEffects,
+            ignoreAdditionalEffects,
+            settings,
+        });
+        this.#generate(settings);
+    }
+
+    async #crossProcess(layer, currentFrame, totalFrames) {
+        const filename = `${this.workingDirectory}cross${randomId()}.png`;
+        await layer.toFile(filename);
+        const jimpImage = await Jimp.read(filename);
+
+        // Nonlinear channel mapping to simulate cross-processing
+        jimpImage.scan(0, 0, jimpImage.bitmap.width, jimpImage.bitmap.height, function (x, y, idx) {
+            const map = (val) => {
+                if (val < 128) {
+                    return Math.round((val * val) / 128);
+                }
+                const v = 255 - val;
+                return Math.round(255 - (v * v) / 128);
+            };
+            this.bitmap.data[idx] = map(this.bitmap.data[idx]);
+            this.bitmap.data[idx + 1] = map(this.bitmap.data[idx + 1]);
+            this.bitmap.data[idx + 2] = map(this.bitmap.data[idx + 2]);
+        });
+
+        // Animate hue shift over time
+        const hue = findValue(
+            this.data.hueShiftRange.lower,
+            this.data.hueShiftRange.upper,
+            this.data.cycleSpeed,
+            totalFrames,
+            currentFrame
+        );
+        await jimpImage.color([{ apply: 'hue', params: [hue] }]);
+
+        // Apply contrast adjustment
+        if (this.data.contrast !== 0) {
+            await jimpImage.contrast(this.data.contrast);
+        }
+
+        await jimpImage.writeAsync(filename);
+        await layer.fromFile(filename);
+        await fs.unlink(filename);
+    }
+
+    #generate(settings) {
+        this.data = {
+            hueShiftRange: {
+                lower: this.config.hueShiftRange.lower,
+                upper: this.config.hueShiftRange.upper,
+            },
+            contrast: randomNumber(this.config.contrast.lower, this.config.contrast.upper),
+            cycleSpeed: getRandomIntInclusive(this.config.cycleSpeed.lower, this.config.cycleSpeed.upper),
+        };
+    }
+
+    async invoke(layer, currentFrame, numberOfFrames) {
+        await this.#crossProcess(layer, currentFrame, numberOfFrames);
+        await super.invoke(layer, currentFrame, numberOfFrames);
+    }
+
+    getInfo() {
+        return `${this.name}: hue ${this.data.hueShiftRange.lower} to ${this.data.hueShiftRange.upper} ${this.data.cycleSpeed}x, contrast ${this.data.contrast.toFixed(2)}`;
+    }
+}


### PR DESCRIPTION
## Summary
- add AnimatedCrossProcessEffect with nonlinear channel mapping and animated hue shift
- register animated-cross-process effect with LayerEffectFromJSON
- document cross-processing effect configuration

## Testing
- `npm test` *(fails: findValue and findMultiStepValue tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b892278cfc8326aed05f6608e9a519