### PR TITLE
Document canvas and layer APIs and blur recipe

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,69 @@
+# my-nft-gen Documentation Hub
+
+## When to use this
+Use this entry point when you need a fast orientation to the project. It links to all other docs and shows the minimum code needed to spin up the engine.
+
+## What the app is
+`my-nft-gen` is a Node.js generative art engine that builds layered 2D compositions with a plugin-based effect system, renders frames via Sharp/SVG, and can export image sequences or MP4s.
+
+## Who it’s for
+- Engineers building custom visual effects or presets.
+- Artists who want to script generative loops with repeatable configs.
+- Contributors who need to understand the render pipeline and registries.
+
+## Docs map
+- [Getting started](quickstart.md)
+- [Architecture overview](architecture.md)
+- Core engine
+  - [Canvas2D](core/canvas2d.md)
+  - [Layer2D](core/layer2d.md)
+- Effects system
+  - [Effects overview](effects/overview.md)
+  - [Creating an effect](effects/creating-an-effect.md)
+  - [Effect config schema](effects/effect-config-schema.md)
+  - [Oscillating blur example](effects/example-oscillating-blur.md)
+- Recipes
+  - [Blur using two layers](recipes/blur-two-layer.md)
+  - [findValue lookups](recipes/find-value.md)
+- Reference & troubleshooting
+  - [Config glossary](reference/config-glossary.md)
+  - [Troubleshooting](troubleshooting.md)
+
+## 30-second usage example
+```javascript
+import { Project, LayerConfig } from 'my-nft-gen';
+import { EnhancedEffectsRegistration } from './src/core/registry/EnhancedEffectsRegistration.js';
+import { EffectRegistry } from './src/core/registry/EffectRegistry.js';
+import { RayRingEffect } from './src/effects/primaryEffects/rayRing/RayRingEffect.js';
+
+// Register built-in effects (required before lookup)
+await EnhancedEffectsRegistration.registerEffectsFromPackage();
+
+const project = new Project({
+    projectName: 'demo-loop',
+    numberOfFrame: 120,
+    longestSideInPixels: 1080,
+    shortestSideInPixels: 1080,
+});
+
+project.addPrimaryEffect({
+    layerConfig: new LayerConfig({
+        name: 'ray-rings',
+        effect: RayRingEffect,
+        percentChance: 100,
+    }),
+});
+
+// Build settings + generate frames
+// (Project.generate orchestrates worker threads and rendering.)
+await project.generate();
+```
+
+Related files
+- `index.js`
+- `src/app/Project.js`
+- `package.json`
+
+See also
+- [Getting started](quickstart.md)
+- [Architecture overview](architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,75 @@
+# Architecture Overview
+
+## When to use this
+Read this to understand how configs, layers, effects, and exports move through the engine before adding new features or debugging renders.
+
+## Data flow
+```
+Config (Project + LayerConfig + EffectConfig)
+    ↓
+Settings.generateEffects() → LoopBuilder (animation plan)
+    ↓
+Canvas2dFactory → Canvas2d (strategy: SvgCanvasStrategy) → draw primitives
+    ↓
+LayerFactory (SharpLayerStrategy) → Layer instances
+    ↓
+LayerEffect.invoke() chains additional effects
+    ↓
+Composition/composite → write via Sharp → ffmpeg pipeline (if exporting video)
+```
+
+## Key modules & responsibilities
+- `src/app/Project.js`
+  - Owns project metadata, effect selections, worker/event wiring.
+  - Provides `addPrimaryEffect/removePrimaryEffect` and triggers generation lifecycle events.
+- `src/core/Settings.js` (imported by effects)
+  - Normalizes working directory, layer strategy, final sizes, and effect lists before rendering.
+- `src/core/factory/canvas/Canvas2dFactory.js`
+  - Builds `Canvas2d` wrappers with a render strategy (currently `SvgCanvasStrategy`).
+- `src/core/factory/canvas/strategy/SvgCanvasStrategy.js`
+  - Renders geometric primitives to SVG strings, converts to PNG buffers via Sharp, and can hand buffers to `LayerFactory`.
+- `src/core/factory/layer/LayerFactory.js`
+  - Produces `Layer` objects backed by `SharpLayerStrategy`; supports new layers, loading from file/buffer, and compositing.
+- `src/core/factory/layer/strategy/SharpLayerStrategy.js`
+  - Implements blur, resize, crop, composite, opacity adjustment, rotate, extend via Sharp; manages buffer lifecycle.
+- `src/core/layer/LayerEffect.js`
+  - Base class for effects; runs `additionalEffects` and exposes metadata for each effect.
+- Registries
+  - `src/core/registry/EffectRegistry.js`, `ConfigRegistry.js`, `PresetRegistry.js` coordinate plugin resolution and presets.
+
+## Lifecycle / pipeline stages
+1. **Register effects:** `EnhancedEffectsRegistration.registerEffectsFromPackage()` populates the registries.
+2. **Select effects:** `Project.addPrimaryEffect({ layerConfig })` pushes `LayerConfig` entries.
+3. **Generate settings:** `Settings.generateEffects()` hydrates effect instances (and their configs) for each frame builder thread.
+4. **Build frame:** Effects allocate canvases/layers, draw primitives, composite layers, and apply secondary effects via `LayerEffect.invoke` chaining.
+5. **Export:** Layers are written to files through `SharpLayerStrategy.toFile`; MP4 or sequences can be produced via ffmpeg helpers (see `src/mp4-test.js` and core/output modules).
+
+## ASCII pipeline
+```
+[Project config]
+      │
+      ▼
+[Settings + registries]
+      │
+      ▼
+[Effect instances] ──► [Canvas2d (SVG→PNG)] ──► [Layer (Sharp)]
+                                      │
+                                      ▼
+                           [Composite & effects]
+                                      │
+                                      ▼
+                               [Export/write]
+```
+
+Related files
+- `src/app/Project.js`
+- `src/core/factory/canvas/Canvas2dFactory.js`
+- `src/core/factory/canvas/strategy/SvgCanvasStrategy.js`
+- `src/core/factory/layer/LayerFactory.js`
+- `src/core/factory/layer/strategy/SharpLayerStrategy.js`
+- `src/core/layer/LayerEffect.js`
+
+See also
+- [Canvas2D](core/canvas2d.md)
+- [Layer2D](core/layer2d.md)
+- [Effects overview](effects/overview.md)

--- a/docs/core/canvas2d.md
+++ b/docs/core/canvas2d.md
@@ -1,0 +1,63 @@
+# Canvas2D
+
+## When to use this
+Reference this when you need to allocate a drawable canvas, render primitives (rings, rays, polygons, text), and export to files or layers. The API is designed for consumption outside this repo via `import { Canvas2dFactory } from 'my-nft-gen';`.
+
+## Purpose & lifecycle
+- `Canvas2d` wraps a render strategy (currently `SvgCanvasStrategy`).
+- Lifecycle:
+  1. `Canvas2dFactory.getNewCanvas(width, height, strategy)` creates the instance and calls `newCanvas`.
+  2. Draw shapes/text via the delegated methods.
+  3. Export with `toFile()` or convert to a `Layer` via `convertToLayer()`.
+  4. Call `dispose()` to clear caches.
+
+## Construction
+```javascript
+import { Canvas2dFactory } from 'my-nft-gen';
+
+const canvas = await Canvas2dFactory.getNewCanvas(640, 640, 'svg');
+```
+
+## API surface (delegated to `SvgCanvasStrategy`)
+All methods return `Promise<void>` unless noted.
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `newCanvas` | `(width, height)` | Reset to a blank canvas. |
+| `toFile` | `(filename)` | Write PNG converted from the SVG stack. |
+| `convertToLayer` | `()` → `Layer` | Renders current SVG into a Sharp-backed `Layer`. |
+| `dispose` | `()` | Clears cached SVG fragments. |
+| `drawRing2d` | `(pos, radius, innerStroke, innerColor, outerStroke, outerColor, alpha)` | Draw a stroked ring. |
+| `drawRay2d` | `(pos, angle, radius, length, innerStroke, innerColor, outerStroke, outerColor)` | Single radial ray. |
+| `drawRays2d` | `(pos, radius, length, sparsityFactor, innerStroke, innerColor, outerStroke, outerColor)` | Fan of rays. |
+| `drawPolygon2d` | `(radius, pos, numberOfSides, startAngle, innerStroke, innerColor, outerStroke, outerColor, alpha)` | Outlined polygon. |
+| `drawFilledPolygon2d` | `(radius, pos, numberOfSides, startAngle, fillColor, alpha)` | Filled polygon. |
+| `drawGradientLine2d` | `(startPos, endPos, stroke, startColor, endColor)` | Linear gradient stroke. |
+| `drawLine2d` | `(startPos, endPos, innerStroke, innerColor, outerStroke, outerColor, alpha)` | Double-stroke line. |
+| `drawBezierCurve` | `(start, control, end, innerStroke, innerColor, outerStroke, outerColor)` | Quadratic Bézier curve. |
+| `drawPath` | `(segment, innerStroke, innerColor, outerStroke, outerColor)` | Accepts array of points or SVG path string. |
+| `drawGradientRect` | `(x, y, width, height, colorStops)` | Color stops are `{ offset, color }`. |
+| `drawText` | `(text, x, y, options)` | Options include font family/size/weight/style, color/alpha, anchor, baseline, letter spacing, decoration, stroke, rotation. |
+
+## Minimal create + render example
+```javascript
+import { Canvas2dFactory } from 'my-nft-gen';
+
+const canvas = await Canvas2dFactory.getNewCanvas(400, 400);
+await canvas.drawRing2d({ x: 200, y: 200 }, 80, 2, '#ff00ff', 6, '#00ffff', 0.9);
+await canvas.drawText('hello', 200, 200, { textAnchor: 'middle', dominantBaseline: 'middle', color: '#ffffff', fontSize: 24 });
+await canvas.toFile('output/ring.png');
+```
+
+## Performance notes
+- `SvgCanvasStrategy` caches built SVG fragments in `this.elements` and clears via `dispose()`.
+- Exports convert SVG → PNG through Sharp; minimize calls to `toFile`/`convertToLayer` for throughput.
+
+Related files
+- `src/core/factory/canvas/Canvas2d.js`
+- `src/core/factory/canvas/Canvas2dFactory.js`
+- `src/core/factory/canvas/strategy/SvgCanvasStrategy.js`
+
+See also
+- [Layer2D](layer2d.md)
+- [Effects overview](../effects/overview.md)

--- a/docs/core/layer2d.md
+++ b/docs/core/layer2d.md
@@ -1,0 +1,68 @@
+# Layer2D
+
+## When to use this
+Use this as a reference for loading, compositing, and transforming raster layers backed by Sharp. The API is consumable outside this repo via `import { LayerFactory } from 'my-nft-gen';`.
+
+## Purpose and mental model
+- `Layer` is a thin wrapper around a strategy (default `SharpLayerStrategy`) that owns a PNG buffer.
+- Treat each layer as a full-size image that can be composited with other layers or written to disk.
+- Coordinate system: top-left origin; widths/heights are passed directly to Sharp, so `(0,0)` is the upper-left corner.
+
+## Creating layers
+```javascript
+import { LayerFactory } from 'my-nft-gen';
+
+const layer = await LayerFactory.getNewLayer(
+    640, // height
+    640, // width
+    { r: 0, g: 0, b: 0, alpha: 0 }, // background
+    { workingDirectory: 'output/', layerStrategy: 'sharp', finalImageSize: { width: 640, height: 640, longestSide: 640, shortestSide: 640 } }
+);
+```
+You can also load from files or buffers via `LayerFactory.getLayerFromFile(filename)` or `getLayerFromBuffer(buffer)`.
+
+## API surface (Sharp-backed)
+All methods return `Promise<void>` unless noted.
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `newLayer` | `(height, width, backgroundColor)` | Create/reset with a filled background. |
+| `fromFile` / `toFile` | `(filename)` | Read/write PNGs. |
+| `fromBuffer` / `toBuffer` | `(buffer)` / `()` → `Buffer` | Stream-safe conversions. |
+| `compositeLayerOver` | `(layer, withoutResize=false)` | Composite another layer, resizing to `finalImageSize` unless `withoutResize` is true. |
+| `compositeLayerOverAtPoint` | `(layer, top, left)` | Place another layer at pixel coordinates. |
+| `blur` | `(byPixels)` | Gaussian blur when `byPixels > 0`. |
+| `adjustLayerOpacity` | `(opacity)` | Opacity in `[0,1]` mapped to 0–255 alpha channel. |
+| `rotate` | `(angle)` | Rotate around center and fit back to original bounds. |
+| `resize` | `(height, width, fitType)` | Uses Sharp fit modes (e.g., `contain`). |
+| `crop` | `(left, top, width, height)` | Safe extract; ignores errors silently. |
+| `extend` | `({ top, bottom, left, right })` | Transparent extension. |
+| `getInfo` | `()` → metadata | Returns Sharp metadata `{ width, height, channels, ... }`. |
+| `modulate` | `({ brightness, saturation, contrast })` | Color adjustments. |
+
+## Layer + effects interaction
+Effects receive `Layer` instances and may:
+- Draw to a temporary canvas (`Canvas2dFactory.getNewCanvas`), convert via `convertToLayer()`, then composite onto the working layer.
+- Chain additional effects through `LayerEffect.invoke` (e.g., secondary/post effects).
+
+## Examples
+### Draw and composite onto another layer
+```javascript
+import { Canvas2dFactory, LayerFactory } from 'my-nft-gen';
+
+const base = await LayerFactory.getNewLayer(400, 400, { r: 0, g: 0, b: 0, alpha: 0 });
+const canvas = await Canvas2dFactory.getNewCanvas(400, 400);
+await canvas.drawFilledPolygon2d(80, { x: 200, y: 200 }, 6, 0, '#00ffcc', 0.8);
+const polygonLayer = await canvas.convertToLayer();
+await base.compositeLayerOver(polygonLayer);
+await base.toFile('output/composited.png');
+```
+
+Related files
+- `src/core/factory/layer/Layer.js`
+- `src/core/factory/layer/LayerFactory.js`
+- `src/core/factory/layer/strategy/SharpLayerStrategy.js`
+
+See also
+- [Canvas2D](canvas2d.md)
+- [Effects overview](../effects/overview.md)

--- a/docs/effects/creating-an-effect.md
+++ b/docs/effects/creating-an-effect.md
@@ -1,0 +1,100 @@
+# Creating an Effect
+
+## When to use this
+Follow these steps when adding a new drawable or post-processing effect to the engine.
+
+## Steps
+1. **Choose location:** Add files under `src/effects/<category>/<EffectName>/` (e.g., `primaryEffects/MyEffect/`).
+2. **Create config class:** Extend `EffectConfig` and expose parameters.
+   ```javascript
+   // src/effects/primaryEffects/MyEffect/MyEffectConfig.js
+   import { EffectConfig } from '../../../core/layer/EffectConfig.js';
+
+   export class MyEffectConfig extends EffectConfig {
+       constructor({ strength = 0.5 } = {}) {
+           super();
+           this.strength = strength;
+       }
+   }
+   ```
+3. **Create effect class:** Extend `LayerEffect`, set static metadata, and implement `invoke`.
+   ```javascript
+   // src/effects/primaryEffects/MyEffect/MyEffectEffect.js
+   import { LayerEffect } from '../../../core/layer/LayerEffect.js';
+   import { MyEffectConfig } from './MyEffectConfig.js';
+
+   export class MyEffectEffect extends LayerEffect {
+       static _name_ = 'my-effect';
+       static configClass = MyEffectConfig;
+
+       constructor({ config = new MyEffectConfig({}), ...rest } = {}) {
+           super({ name: MyEffectEffect._name_, requiresLayer: true, config, ...rest });
+       }
+
+       async invoke(layer, currentFrame, numberOfFrames) {
+           // draw or modify the layer here
+           await super.invoke(layer, currentFrame, numberOfFrames);
+       }
+   }
+   ```
+4. **Register the effect:** Use `EffectRegistry.registerGlobal(name, EffectClass)` or rely on `EnhancedEffectsRegistration.registerEffectsFromPackage()` to auto-register packaged effects.
+5. **Use it in a project:**
+   ```javascript
+   import { Project, LayerConfig } from 'my-nft-gen';
+   import { MyEffectEffect } from './src/effects/primaryEffects/MyEffect/MyEffectEffect.js';
+   import { EnhancedEffectsRegistration } from './src/core/registry/EnhancedEffectsRegistration.js';
+
+   await EnhancedEffectsRegistration.registerEffectsFromPackage();
+
+   const project = new Project({ numberOfFrame: 60 });
+   project.addPrimaryEffect({
+       layerConfig: new LayerConfig({
+           name: 'my-effect',
+           effect: MyEffectEffect,
+           percentChance: 100,
+           currentEffectConfig: { strength: 0.8 },
+       }),
+   });
+   await project.generate();
+   ```
+
+## Hello world overlay example
+```javascript
+import { Canvas2dFactory } from 'my-nft-gen';
+import { LayerEffect } from '../../../core/layer/LayerEffect.js';
+import { EffectConfig } from '../../../core/layer/EffectConfig.js';
+
+class HelloConfig extends EffectConfig {
+    constructor({ text = 'hello world' } = {}) {
+        super();
+        this.text = text;
+    }
+}
+
+export class HelloEffect extends LayerEffect {
+    static _name_ = 'hello-overlay';
+    static configClass = HelloConfig;
+
+    constructor({ config = new HelloConfig({}), ...rest } = {}) {
+        super({ name: HelloEffect._name_, requiresLayer: true, config, ...rest });
+    }
+
+    async invoke(layer, currentFrame, totalFrames) {
+        const canvas = await Canvas2dFactory.getNewCanvas(layer.finalImageSize?.width || 400, layer.finalImageSize?.height || 400);
+        await canvas.drawText(this.config.text, 20, 40, { color: '#ffffff', fontSize: 24 });
+        const overlay = await canvas.convertToLayer();
+        await layer.compositeLayerOver(overlay, true);
+        await super.invoke(layer, currentFrame, totalFrames);
+    }
+}
+```
+
+Related files
+- `src/core/layer/LayerEffect.js`
+- `src/core/layer/EffectConfig.js`
+- `src/core/registry/EffectRegistry.js`
+- `src/core/registry/EnhancedEffectsRegistration.js`
+
+See also
+- [Effects overview](overview.md)
+- [Effect config schema](effect-config-schema.md)

--- a/docs/effects/effect-config-schema.md
+++ b/docs/effects/effect-config-schema.md
@@ -1,0 +1,96 @@
+# Effect Config Schema
+
+## When to use this
+Consult this when shaping config objects for effects or writing presets.
+
+## Conventions
+- Config classes extend `EffectConfig` (`src/core/layer/EffectConfig.js`). Validation is currently a TODO (stubbed `validate()` method).
+- Effects often expose `static configClass` and `static presets` to describe expected keys.
+- Numeric ranges are frequently expressed as `{ lower, upper }` objects; some effects nest these under `bottom`/`top` entries.
+
+## Required vs optional
+- Unless enforced by the effect’s constructor, fields are optional. Effects typically supply defaults in the config constructor.
+- `LayerConfig` wraps an effect with `percentChance` and `ignoreSecondaryEffects` flags; these are required when instantiating the layer config but not inside the effect config itself.
+
+## Real config examples
+### RayRingEffect preset (primary effect)
+From `RayRingEffect.presets`:
+```javascript
+{
+    name: 'simple-ray-rings',
+    effect: 'ray-rings',
+    percentChance: 100,
+    currentEffectConfig: {
+        layerOpacity: 0.8,
+        underLayerOpacity: 0.6,
+        circles: { lower: 2, upper: 4 },
+        radiusInitial: 200,
+        radiusGap: 40,
+        stroke: 1,
+        thickness: 1,
+        rayStroke: 1,
+        rayThickness: 1,
+        scaleFactor: 1.15,
+        densityFactor: 1.5,
+        accentRange: { bottom: { lower: 0, upper: 0 }, top: { lower: 2, upper: 4 } },
+        blurRange: { bottom: { lower: 0, upper: 0 }, top: { lower: 1, upper: 2 } },
+        featherTimes: { lower: 1, upper: 2 },
+        lengthRange: { bottom: { lower: 3, upper: 8 }, top: { lower: 10, upper: 30 } },
+        lengthTimes: { lower: 1, upper: 3 },
+        sparsityFactor: [2, 3],
+        speed: { lower: 0, upper: 0 },
+        center: new Position({x: 1080 / 2, y: 1920 / 2}),
+    }
+}
+```
+Key patterns: scalar numbers, `{lower, upper}` ranges, arrays for discrete picks, and rich objects (e.g., `Position`).
+
+### SingleLayerBlurConfig defaults (secondary effect)
+```javascript
+new SingleLayerBlurConfig({
+    lowerRange: new Range(0, 0),
+    upperRange: new Range(2, 6),
+    times: new Range(2, 9),
+    glitchChance: 100,
+});
+```
+Effect logic then samples `lowerRange`/`upperRange`/`times` to derive blur values each frame and checks `glitchChance` before invoking `layer.blur()`.
+
+### Config reconstruction test (FuzzFlareEffect)
+`src/mp4-test.js` constructs a `LayerConfig` with serialized fields:
+```javascript
+new LayerConfig({
+    name: 'fuzz-flare',
+    effect: FuzzFlareEffect,
+    percentChance: 100,
+    currentEffectConfig: {
+        flareRingsSizeRange: {
+            __className: 'PercentageRange',
+            lower: { percent: 0.1 },
+            upper: { percent: 0.2 }
+        },
+        innerColor: {
+            __className: 'ColorPicker',
+            selectionType: 'colorBucket',
+            colorValue: null
+        }
+    }
+})
+```
+The engine reconstructs class instances (e.g., `PercentageRange`, `ColorPicker`) during `Settings.generateEffects()`.
+
+## Validation/normalization
+- `EffectConfig.validate()` is currently empty; effects themselves should defensively handle missing keys.
+- `LayerFactory.compositeLayerOver` automatically resizes layers to `finalImageSize` unless `withoutResize` is `true`, which normalizes layer dimensions during compositing.
+
+Related files
+- `src/core/layer/EffectConfig.js`
+- `src/effects/primaryEffects/rayRing/RayRingEffect.js`
+- `src/effects/secondaryEffects/single-layer-blur/SingleLayerBlurConfig.js`
+- `src/effects/secondaryEffects/single-layer-blur/SingleLayerBlurEffect.js`
+- `src/mp4-test.js`
+
+See also
+- [Creating an effect](creating-an-effect.md)
+- [Config glossary](../reference/config-glossary.md)
+- [Oscillating blur example](example-oscillating-blur.md)

--- a/docs/effects/example-oscillating-blur.md
+++ b/docs/effects/example-oscillating-blur.md
@@ -1,0 +1,103 @@
+# Example: Oscillating Blur Overlay Effect
+
+## When to use this
+Use this as a template for a lightweight effect that draws on a `Canvas2d`, converts to a `Layer`, animates blur with `findValue`, and composites over the current frame.
+
+## Minimal implementation
+```javascript
+// src/effects/secondaryEffects/pulse-blur/PulseBlurEffect.js
+import { LayerEffect } from '../../../core/layer/LayerEffect.js';
+import { EffectConfig } from '../../../core/layer/EffectConfig.js';
+import { Canvas2dFactory } from '../../../core/factory/canvas/Canvas2dFactory.js';
+import { findValue, FindValueAlgorithm } from '../../../core/math/findValue.js';
+import { Range } from '../../../core/layer/configType/Range.js';
+
+class PulseBlurConfig extends EffectConfig {
+    constructor({ blurRange = new Range(2, 6), times = 2, text = 'pulse' } = {}) {
+        super();
+        this.blurRange = blurRange;
+        this.times = times;
+        this.text = text;
+    }
+}
+
+export class PulseBlurEffect extends LayerEffect {
+    static _name_ = 'pulse-blur';
+    static configClass = PulseBlurConfig;
+
+    constructor({ config = new PulseBlurConfig({}), ...rest } = {}) {
+        super({ name: PulseBlurEffect._name_, requiresLayer: true, config, ...rest });
+    }
+
+    async invoke(layer, currentFrame, totalFrames) {
+        const width = this.finalSize?.width ?? 640;
+        const height = this.finalSize?.height ?? 640;
+
+        const canvas = await Canvas2dFactory.getNewCanvas(width, height);
+        await canvas.drawGradientRect(0, 0, width, height, [
+            { offset: 0, color: '#101018' },
+            { offset: 1, color: '#7027ff' },
+        ]);
+        await canvas.drawText(this.config.text, width / 2, height / 2, {
+            textAnchor: 'middle',
+            dominantBaseline: 'middle',
+            color: '#ffffff',
+            fontSize: 64,
+        });
+
+        const overlay = await canvas.convertToLayer();
+        const blurByPixels = Math.floor(
+            findValue(
+                this.config.blurRange.lower,
+                this.config.blurRange.upper,
+                this.config.times,
+                totalFrames,
+                currentFrame,
+                FindValueAlgorithm.JOURNEY_SIN,
+            ),
+        );
+        if (blurByPixels > 0) {
+            await overlay.blur(blurByPixels);
+        }
+        await overlay.adjustLayerOpacity(0.8);
+        await layer.compositeLayerOver(overlay);
+
+        await super.invoke(layer, currentFrame, totalFrames);
+    }
+}
+```
+
+## Usage snippet
+```javascript
+import { LayerConfig } from 'my-nft-gen/src/core/layer/LayerConfig.js';
+import { EnhancedEffectsRegistration } from 'my-nft-gen/src/core/registry/EnhancedEffectsRegistration.js';
+import { PulseBlurEffect } from './src/effects/secondaryEffects/pulse-blur/PulseBlurEffect.js';
+
+await EnhancedEffectsRegistration.registerEffectsFromPackage();
+
+const layerConfig = new LayerConfig({
+    name: 'pulse-blur',
+    effect: PulseBlurEffect,
+    percentChance: 100,
+    currentEffectConfig: {
+        blurRange: { lower: 1, upper: 5 },
+        times: 3,
+        text: 'hello svg',
+    },
+});
+// Attach layerConfig to your project/layer pipeline as shown in quickstart.
+```
+
+Related files
+- `src/core/factory/canvas/Canvas2dFactory.js`
+- `src/core/factory/canvas/Canvas2d.js`
+- `src/core/layer/LayerEffect.js`
+- `src/core/layer/EffectConfig.js`
+- `src/core/math/findValue.js`
+- `src/core/layer/configType/Range.js`
+- `src/effects/secondaryEffects/single-layer-blur/SingleLayerBlurEffect.js`
+
+See also
+- [Effects overview](overview.md)
+- [Creating an effect](creating-an-effect.md)
+- [Effect config schema](effect-config-schema.md)

--- a/docs/effects/overview.md
+++ b/docs/effects/overview.md
@@ -1,0 +1,48 @@
+# Effects Overview
+
+## When to use this
+Start here to understand how effects are represented, invoked, and wired into layers/canvases.
+
+## What is an effect?
+- An effect is a subclass of `LayerEffect` that draws or post-processes a `Layer`.
+- Each effect carries a config object (often a dedicated `*Config` class) plus optional `additionalEffects` that run afterward.
+- Effects are registered in `EffectRegistry` and may expose presets via `PresetRegistry`; the plugin-based `EnhancedEffectsRegistration.registerEffectsFromPackage()` migrates these into legacy registries for consumption.
+
+## Lifecycle hooks
+- **constructor:** Accepts `{ name, requiresLayer, config, additionalEffects, ignoreAdditionalEffects, settings }`, sets up registry-related metadata, and may preload assets.
+- **invoke(layer, currentFrame, totalFrames):** Main entry point called per frame; base class iterates `additionalEffects` unless `ignoreAdditionalEffects` is `true`.
+- **getInfo():** Returns a short descriptor string.
+
+## How effects receive params/config
+- Config objects are passed into the effect constructor (`config` param) and stored as `this.config`.
+- Many effects define `static configClass` and `static presets` (see `RayRingEffect` and `SingleLayerBlurEffect`), enabling config hydration through registries.
+- `Settings` injects render context: `layerStrategy`, `finalSize`, `workingDirectory`, `fileConfig`.
+
+## Applying effects to layers/canvas
+- Effects often create a `Canvas2d` instance, draw primitives, convert to a `Layer`, then composite it over an existing `Layer` using `LayerFactory` operations (e.g., `compositeLayerOver`, `adjustLayerOpacity`).
+- Secondary/post effects are executed by the base `LayerEffect.invoke` loop.
+
+## Representative examples and patterns
+- **Geometry + glow:** `src/effects/primaryEffects/rayRing/RayRingEffect.js`
+  - Draws concentric rings/rays on a `Canvas2d`, composites two saved layers, feathers edges with `findValue`-driven blur, and animates ray lengths/accents frame-by-frame.
+- **Single-layer post blur:** `src/effects/secondaryEffects/single-layer-blur/SingleLayerBlurEffect.js`
+  - Randomly picks blur bounds/times from `Range` configs, uses `findValue` to oscillate blur per frame, and calls `layer.blur()` when a glitch chance check passes.
+- **Keyframe modulation:** `src/effects/keyFrameEffects/pixelate/PixelateKeyFrameEffect.js`
+  - Samples `findValue` to raise/lower pixelation strength across frames, relying on `Layer.blur`/resize-like operations for stylized stepping.
+- **Final image CRT distortion:** `src/effects/finalImageEffects/claudeCRTBarrelRoll/ClaudeCRTBarrelRollEffect.js`
+  - Applies `findValue`-driven barrel distortion and rolling offsets in a post-process stage, operating on the final composited layer.
+
+Related files
+- `src/core/layer/LayerEffect.js`
+- `src/core/layer/EffectConfig.js`
+- `src/core/registry/EffectRegistry.js`
+- `src/core/registry/EnhancedEffectsRegistration.js`
+- `src/effects/primaryEffects/rayRing/RayRingEffect.js`
+- `src/effects/secondaryEffects/single-layer-blur/SingleLayerBlurEffect.js`
+- `src/effects/keyFrameEffects/pixelate/PixelateKeyFrameEffect.js`
+- `src/effects/finalImageEffects/claudeCRTBarrelRoll/ClaudeCRTBarrelRollEffect.js`
+
+See also
+- [Creating an effect](creating-an-effect.md)
+- [Effect config schema](effect-config-schema.md)
+- [Oscillating blur example](example-oscillating-blur.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart
+
+## When to use this
+Follow this guide to install dependencies, register effects, and render a test loop or MP4 using the built-in scripts.
+
+## Install
+```bash
+npm install
+```
+
+## Run / build / generate output
+- **Smoke test render:**
+  ```bash
+  npm run quick-test   # runs node src/mp4-test.js
+  ```
+  `src/mp4-test.js` constructs a small `Project`, registers effects via `EnhancedEffectsRegistration.registerEffectsFromPackage()`, and generates a 3-frame sample using Sharp.
+- **Test suite:**
+  ```bash
+  npm test
+  ```
+- **Programmatic render (example):**
+  ```javascript
+  import { Project, LayerConfig } from 'my-nft-gen';
+  import { EnhancedEffectsRegistration } from './src/core/registry/EnhancedEffectsRegistration.js';
+  import { RayRingEffect } from './src/effects/primaryEffects/rayRing/RayRingEffect.js';
+
+  await EnhancedEffectsRegistration.registerEffectsFromPackage();
+
+  const project = new Project({
+      projectName: 'quick-demo',
+      numberOfFrame: 60,
+      longestSideInPixels: 640,
+      shortestSideInPixels: 640,
+      workingDirectory: 'output/',
+  });
+
+  project.addPrimaryEffect({
+      layerConfig: new LayerConfig({
+          name: 'ray-rings',
+          effect: RayRingEffect,
+          percentChance: 100,
+      }),
+  });
+
+  await project.generate();
+  ```
+
+## Expected inputs/outputs
+- **Inputs:**
+  - Node.js ≥18.
+  - Effect registration via `EnhancedEffectsRegistration.registerEffectsFromPackage()` (loads built-ins from `src/effects`).
+  - Layer strategy defaults to Sharp; files saved under the configured `workingDirectory`.
+- **Outputs:**
+  - Generated frame files or MP4s in the chosen working directory (e.g., `test-output/` in `src/mp4-test.js`).
+  - Presets and registry metadata are stored in memory during runtime.
+
+## Common failure modes + fixes
+- **Effect not found in registry:** Ensure `EnhancedEffectsRegistration.registerEffectsFromPackage()` is called before `EffectRegistry.getGlobal()` or before constructing `LayerConfig` with an effect class.
+- **Missing working directory:** `Project` does not auto-create directories in `src/mp4-test.js`; ensure the `workingDirectory` exists or create it before running.
+- **Zero-length renders:** `findValue` returns early when `totalFrame` or `times` is `0`; pass non-zero values in configs that drive animated parameters.
+
+Related files
+- `package.json`
+- `src/mp4-test.js`
+- `src/app/Project.js`
+
+See also
+- [Architecture overview](architecture.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/recipes/blur-two-layer.md
+++ b/docs/recipes/blur-two-layer.md
@@ -1,0 +1,51 @@
+# Recipe: Blur Using Two Layers
+
+## When to use this
+Use this pattern to add a soft glow/blur without destroying the sharp foreground by compositing a blurred copy underneath. Blur here means two identical drawings overlaid: one stays crisp, one is blurred (often at lower opacity) with both blur radius and opacity driven by `findValue` for animation.
+
+## Approach
+1. Render your sharp content to a base `Layer`.
+2. Duplicate the base into a blur layer (`LayerFactory.getLayerFromBuffer(await base.toBuffer())`).
+3. Compute blur radius/opacity using `findValue` so frames animate smoothly.
+4. Apply `blur()` and `adjustLayerOpacity()` to the blur layer.
+5. Composite the blurred layer over (or under) the base using `compositeLayerOver`.
+
+## Example (Sharp layer APIs + `findValue`)
+```javascript
+import { Canvas2dFactory, LayerFactory, findValue, FindValueAlgorithm } from 'my-nft-gen';
+
+// Step 1: draw crisp content once
+const base = await LayerFactory.getNewLayer(640, 640, { r: 0, g: 0, b: 0, alpha: 0 });
+const canvas = await Canvas2dFactory.getNewCanvas(640, 640);
+await canvas.drawRing2d({ x: 320, y: 320 }, 120, 2, '#ff00ff', 8, '#00ffff', 0.9);
+const crispLayer = await canvas.convertToLayer();
+await base.compositeLayerOver(crispLayer, true);
+
+// Step 2: duplicate and animate blur/opacity with findValue
+const blurLayer = await LayerFactory.getLayerFromBuffer(await base.toBuffer(), {
+    finalImageSize: { width: 640, height: 640, longestSide: 640, shortestSide: 640 },
+    workingDirectory: 'output/',
+});
+const blurRadius = findValue(2, 14, 2, /*totalFrames=*/60, /*currentFrame=*/30, FindValueAlgorithm.JOURNEY_SIN);
+const blurOpacity = findValue(0.35, 0.7, 2, 60, 30, FindValueAlgorithm.JOURNEY_SIN);
+await blurLayer.blur(blurRadius);
+await blurLayer.adjustLayerOpacity(blurOpacity);
+
+// Step 3: composite blurred copy over the crisp base
+await base.compositeLayerOver(blurLayer, true);
+await base.toFile('output/blurred-composite.png');
+```
+
+## Why two layers?
+- `SharpLayerStrategy.blur()` mutates the image; keeping a crisp base preserves details while the blurred copy adds glow.
+- Using `findValue` to drive both `blur()` and `adjustLayerOpacity()` ensures the overlay stays in sync with animation timing.
+
+Related files
+- `src/core/factory/layer/LayerFactory.js`
+- `src/core/factory/layer/strategy/SharpLayerStrategy.js`
+- `src/core/factory/canvas/Canvas2d.js`
+- `src/core/math/findValue.js`
+
+See also
+- [Layer2D](../core/layer2d.md)
+- [Effects overview](../effects/overview.md)

--- a/docs/recipes/find-value.md
+++ b/docs/recipes/find-value.md
@@ -1,0 +1,51 @@
+# Recipe: Using `findValue`
+
+## When to use this
+Use `findValue` to compute oscillating parameter values across animation frames (e.g., opacity, blur, hue) using loop-safe algorithms.
+
+## Location & signature
+- Defined in `src/core/math/findValue.js`.
+- Signature:
+  ```javascript
+  findValue(min, max, times, totalFrame, currentFrame, algorithm = FindValueAlgorithm.JOURNEY_SIN, precision = 10000)
+  ```
+- Returns a number between `min` and `max`. If `max === min`, `totalFrame === 0`, or `times === 0`, it returns `min` early.
+
+## Supported patterns
+- Algorithms come from `FindValueAlgorithm` (e.g., `JOURNEY_SIN`, `ELASTIC_BOUNCE`, `PULSE_WAVE`, `OCEAN_TIDE`).
+- Phase offsets are built-in per algorithm for staggered peaks.
+- Uses `times` to control oscillation cycles over `totalFrame`.
+
+## Examples
+### Basic lookup
+```javascript
+import { findValue, FindValueAlgorithm } from 'my-nft-gen';
+
+const val = findValue(0, 10, 1, 100, 50); // midpoint using default JOURNEY_SIN envelope
+```
+
+### Lookup with default/fallback
+```javascript
+const constant = findValue(5, 5, 2, 100, 40); // returns 5 immediately because min === max
+```
+
+### Nested/animated config usage
+Used inside effects, e.g., `RayRingEffect` animates ray length per frame:
+```javascript
+const length = findValue(
+    context.data.circles[i].rays[rayIndex].length.lower,
+    context.data.circles[i].rays[rayIndex].length.upper,
+    context.data.circles[i].rays[rayIndex].lengthTimes,
+    context.numberOfFrames,
+    context.currentFrame
+);
+```
+
+Related files
+- `src/core/math/findValue.js`
+- `src/effects/primaryEffects/rayRing/RayRingEffect.js`
+- `tests/findValue.test.js`
+
+See also
+- [Effect config schema](../effects/effect-config-schema.md)
+- [Config glossary](../reference/config-glossary.md)

--- a/docs/reference/config-glossary.md
+++ b/docs/reference/config-glossary.md
@@ -1,0 +1,38 @@
+# Config Glossary
+
+## When to use this
+Use this glossary to decode common config keys used across projects, layer configs, and effects.
+
+### Canvas / project
+- `numberOfFrame` – total frames to render (`Project` constructor).
+- `longestSideInPixels` / `shortestSideInPixels` – base dimensions; drive `Project.width/height` getters.
+- `isHorizontal` – swaps width/height orientation.
+- `workingDirectory` – output path used by layers/effects for temporary files.
+- `layerStrategy` – rendering backend (`sharp` default) used by `LayerFactory`.
+
+### Layer
+- `finalImageSize` – `{ width, height, longestSide, shortestSide }`; used by `LayerFactory` and `SharpLayerStrategy` to constrain composites/resizes.
+- `backgroundColor` – RGBA object when calling `LayerFactory.getNewLayer`.
+- `percentChance` – probability that a `LayerConfig` effect is selected.
+- `ignoreSecondaryEffects` – skip `additionalEffects` when true.
+
+### Effect (examples)
+- `currentEffectConfig` – concrete config object passed into an effect (keys vary per effect).
+- `times` – oscillation cycles for animated parameters (used by `findValue`).
+- `blurRange` / `accentRange` / `lengthRange` – common range objects with `{ lower, upper }` or nested `bottom/top` ranges.
+- `layerOpacity` / `underLayerOpacity` – blending amounts before compositing (see `RayRingEffect` presets).
+- `center` – often a `Position` with `{ x, y }` used for radial effects.
+
+### Export
+- `workingDirectory` – ensures temp files can be written before ffmpeg/export.
+- `ffmpegConfig` – optional config passed to `Project` for video output (see `FFmpegConfig` export in `index.js`).
+
+Related files
+- `src/app/Project.js`
+- `src/core/factory/layer/LayerFactory.js`
+- `src/core/factory/layer/strategy/SharpLayerStrategy.js`
+- `src/effects/primaryEffects/rayRing/RayRingEffect.js`
+
+See also
+- [Effect config schema](../effects/effect-config-schema.md)
+- [Quickstart](../quickstart.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,34 @@
+# Troubleshooting
+
+## When to use this
+Check these fixes for common runtime issues observed in the codebase.
+
+- **Effect class not found in registry**
+  - Symptom: `EffectRegistry.getGlobal(...)` returns `undefined` (see guard in `src/mp4-test.js`).
+  - Fix: Call `EnhancedEffectsRegistration.registerEffectsFromPackage()` before resolving effects.
+
+- **Images not resized when compositing**
+  - Symptom: Layers overflow or clip when overlaying.
+  - Fix: Use `Layer.compositeLayerOver(layer)` without `withoutResize=true` so `SharpLayerStrategy` auto-resizes both layers to `finalImageSize`.
+
+- **Blur/opacity no-op**
+  - Symptom: `blur()` or `adjustLayerOpacity()` appears ineffective.
+  - Fix: Ensure the layer buffer is initialized (`newLayer` or `fromFile`). `SharpLayerStrategy.blur` skips when `byPixels <= 0`; pass a positive value. `adjustLayerOpacity` expects `opacity` in `[0,1]`.
+
+- **Zero animation movement**
+  - Symptom: Animated parameters stay constant.
+  - Fix: `findValue` returns early when `totalFrame` or `times` is `0`; verify configs set non-zero counts.
+
+- **Missing output directory**
+  - Symptom: File writes fail in custom scripts.
+  - Fix: Create the `workingDirectory` before calling `toFile`/`generate` (e.g., `test-output/` in `src/mp4-test.js`).
+
+Related files
+- `src/core/registry/EffectRegistry.js`
+- `src/mp4-test.js`
+- `src/core/factory/layer/strategy/SharpLayerStrategy.js`
+- `src/core/math/findValue.js`
+
+See also
+- [Quickstart](quickstart.md)
+- [Config glossary](reference/config-glossary.md)


### PR DESCRIPTION
## Summary
- expand Canvas2D and Layer2D docs with full external API tables and import guidance
- clarify the blur recipe to emphasize two overlaid copies with findValue-driven blur radius and opacity

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694000dae1888326b7b2d650a27e37aa)